### PR TITLE
Disable HS200 mode for eMMC

### DIFF
--- a/Driver/SdhciMMCHSDxe/MMCHS.h
+++ b/Driver/SdhciMMCHSDxe/MMCHS.h
@@ -36,6 +36,7 @@ typedef struct {
   EFI_BLOCK_IO_MEDIA    BlockMedia;
   MMCHS_DEVICE_PATH     DevicePath;
   struct mmc_device *   MmcDev;
+  EFI_EVENT             ExitBsEvent;
 } BIO_INSTANCE;
 
 #define BIO_INSTANCE_SIGNATURE SIGNATURE_32('e', 'm', 'm', 'c')
@@ -75,6 +76,8 @@ MMCHSFlushBlocks(IN EFI_BLOCK_IO_PROTOCOL *This);
 
 EFI_STATUS
 BioInstanceContructor(OUT BIO_INSTANCE **NewInstance);
+
+VOID EFIAPI MMCHSExitBsUninit(IN EFI_EVENT Event, IN VOID *Context);
 
 /* API: to initialize the controller */
 void sdhci_init(struct sdhci_host *);
@@ -118,5 +121,7 @@ bool mmc_set_drv_type(
     struct sdhci_host *host, struct mmc_card *card, uint8_t drv_type);
 /* API: Send the read & write command sequence to rpmb */
 uint32_t mmc_sdhci_rpmb_send(struct mmc_device *dev, struct mmc_command *cmd);
+/* API: De-init the card */
+void mmc_put_card_to_sleep_disable_hc(struct mmc_device *dev);
 
 #endif

--- a/Driver/SdhciMMCHSDxe/SdhciMMCHS.inf
+++ b/Driver/SdhciMMCHSDxe/SdhciMMCHS.inf
@@ -41,6 +41,7 @@
 
 [Guids]
   gEfiEventVirtualAddressChangeGuid
+  gEfiEventExitBootServicesGuid
 
 [FeaturePcd]
   gQcomTokenSpaceGuid.PcdMmcHs200Caps

--- a/Driver/SdhciMMCHSDxe/mmc_sdhci.c
+++ b/Driver/SdhciMMCHSDxe/mmc_sdhci.c
@@ -2297,6 +2297,13 @@ uint32_t mmc_set_clr_power_on_wp_user(
   return 0;
 }
 
+/* Function to put the mmc card to sleep and disable HC */
+void mmc_put_card_to_sleep_disable_hc(struct mmc_device *dev)
+{
+  mmc_put_card_to_sleep(dev);
+  sdhci_mode_disable(&dev->host);
+}
+
 /* Function to put the mmc card to sleep */
 void mmc_put_card_to_sleep(struct mmc_device *dev)
 {

--- a/Library/TargetMmcSdhciLib/QcomTargetMmcSdhciLib.c
+++ b/Library/TargetMmcSdhciLib/QcomTargetMmcSdhciLib.c
@@ -35,8 +35,7 @@ VOID LibQcomTargetMmcSdhciInit(INIT_SLOT_CB InitSlot)
   config.sdhc_base     = mmc_sdhci_base[config.slot - 1];
   config.pwrctl_base   = mmc_pwrctl_base[config.slot - 1];
   config.pwr_irq       = mmc_sdc_pwrctl_irq[config.slot - 1];
-  config.hs200_support = 1;
-  config.hs400_support = 0;
+  config.hs200_support = 0;
 
   clk = TLMM_CUR_VAL_10MA;
   cmd = TLMM_CUR_VAL_8MA;

--- a/Lumia950XLPkg.dec
+++ b/Lumia950XLPkg.dec
@@ -185,7 +185,7 @@
   gQcomTokenSpaceGuid.PcdMmcBamSupport|FALSE|BOOLEAN|0x00010002
 
   # SdhciMMCHSDxe
-  gQcomTokenSpaceGuid.PcdMmcHs200Caps|FALSE|BOOLEAN|0x00010010
+  gQcomTokenSpaceGuid.PcdMmcHs200Caps|TRUE|BOOLEAN|0x00010010
 
   # ScmDxe
   gQcomTokenSpaceGuid.PcdTcsrBootMiscDetect|0|UINT64|0x000000a0

--- a/Tools/PsModules/redirector.psm1
+++ b/Tools/PsModules/redirector.psm1
@@ -43,8 +43,8 @@ function Get-GnuAarch64CrossCollectionPath
 
     if (($null -eq $ccprefix) -and $AllowFallback) 
     {
-        $ccprefix = "/usr/bin/aarch64-linux-gnu-"
-        Write-Warning -Message "GCC not found, fallback to /usr/bin/aarch64-linux-gnu- prefix."
+        $ccprefix = "/opt/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-elf/bin/aarch64-elf-"
+        Write-Warning -Message "GCC not found, fallback to /opt/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-elf/bin/aarch64-elf- prefix."
     }
 
     # Now it's not the fallback case


### PR DESCRIPTION
A well-known eMMC vendor (i.e., Samsung moviNAND) is known for its unpredictable firmware when the eMMC is configured in HS200 mode (HS400 is not affected). Occasionally, the device will show `AUTO CMD12 ERROR`, `CARD NOT IN TRANS STATE` when performing I/O operations. In some instances, the device will fail to boot due to unsuccessful I/O operations.

Hapanero ship with Toshiba eMMC, and hence they are not affected. Since most Lumia 950 (XL) ship with Samsung eMMC, we will disable HS200 globally anyway.

This PR needs further testing.