### PR TITLE
RPM: Make protocol installation optional.

### DIFF
--- a/Driver/SmdRpmDxe/RpmDxe.inf
+++ b/Driver/SmdRpmDxe/RpmDxe.inf
@@ -44,5 +44,8 @@
   gQcomTokenSpaceGuid.PcdApcsAlias0IpcInterrupt
   gQcomTokenSpaceGuid.PcdSmdIrq
 
+[FeaturePcd]
+  gQcomTokenSpaceGuid.PcdInstallRpmProtocol
+
 [Depex]
   gHardwareInterruptProtocolGuid

--- a/Lumia950XLPkg.dec
+++ b/Lumia950XLPkg.dec
@@ -191,4 +191,7 @@
   gQcomTokenSpaceGuid.PcdTcsrBootMiscDetect|0|UINT64|0x000000a0
 
   # LK Build
-  gLumia950XLPkgTokenSpaceGuid.PcdIsLkBuild|TRUE|BOOLEAN|0x00000b101
+  gLumia950XLPkgTokenSpaceGuid.PcdIsLkBuild|TRUE|BOOLEAN|0x0000b101
+
+  # RPM
+  gQcomTokenSpaceGuid.PcdInstallRpmProtocol|FALSE|BOOLEAN|0x00000c100


### PR DESCRIPTION
RPM occupies a SMD (shared memory device) channel, hence it is necessary to
release RPM channel before transferring control to the OS. However, what we
can do is limited in ExitBootServices callback.

We used to workaround the problem using a while-loop combined with thread
sleep, but the mitigation is problematic under the context of uni-core
environment. Since RPM usage is limited in current UEFI implementation,
we will release the RPM channel as soon as possible and using the
non-blocking signaling (semaphore) mechanism.