### PR TITLE
ACPI: Add Side Interaction Device back into ACPI tables

### DIFF
--- a/AcpiTables/8992/src/DSDT.asl
+++ b/AcpiTables/8992/src/DSDT.asl
@@ -19248,8 +19248,161 @@ DefinitionBlock ("", "DSDT", 2, "QCOMM ", "MSM8992 ", 0x00000007)
                     }
                 }
             })
-            Name (CHXC, Package (0x04)
+            Name (CHXC, Package (0x05)
             {
+                Package (0x06)
+                {
+                    "DEVICE",
+                    "\\_SB.SIAD", 		
+                    Package (0x06)		
+                    {		
+                        "DSTATE", 		
+                        Zero, 		
+                        Package (0x02)		
+                        {		
+                            "PMICVREGVOTE", 		
+                            Package (0x0E)		
+                            {		
+                                "PPP_RESOURCE_ID_SMPS4_A", 		
+                                0x02, 		
+                                0x001B7740, 		
+                                0x000493E0, 		
+                                One, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero, 		
+                                0x05, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero		
+                            }		
+                        }, 		
+                        Package (0x02)		
+                        {		
+                            "PMICVREGVOTE", 		
+                            Package (0x06)		
+                            {		
+                                "PPP_RESOURCE_ID_LVS2_A", 		
+                                0x04, 		
+                                0x001B7740, 		
+                                0x000493E0, 		
+                                One, 		
+                                Zero		
+                            }		
+                        }, 		
+                        Package (0x02)		
+                        {		
+                            "PMICVREGVOTE", 		
+                            Package (0x0A)		
+                            {		
+                                "PPP_RESOURCE_ID_LDO18_A", 		
+                                One, 		
+                                0x002B7CD0, 		
+                                0x000927C0, 		
+                                One, 		
+                                Zero, 		
+                                One, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero		
+                            }		
+                        }, 		
+                        Package (0x02)		
+                        {		
+                            "TLMMGPIO", 		
+                            Package (0x06)		
+                            {		
+                                0x27, 		
+                                One, 		
+                                Zero, 		
+                                One, 		
+                                Zero, 		
+                                Zero		
+                            }		
+                        }		
+                    }, 		
+                    Package (0x02)		
+                    {		
+                        "DSTATE", 		
+                        One		
+                    }, 		
+                    Package (0x02)		
+                    {		
+                        "DSTATE", 		
+                        0x02		
+                    }, 		
+                    Package (0x06)		
+                    {		
+                        "DSTATE", 		
+                        0x03, 		
+                        Package (0x02)		
+                        {		
+                            "PMICVREGVOTE", 		
+                            Package (0x0E)		
+                            {		
+                                "PPP_RESOURCE_ID_SMPS4_A", 		
+                                0x02, 		
+                                0x001B7740, 		
+                                0x000493E0, 		
+                                One, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero, 		
+                                0x05, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero		
+                            }		
+                        }, 		
+                        Package (0x02)		
+                        {		
+                            "PMICVREGVOTE", 		
+                            Package (0x06)		
+                            {		
+                                "PPP_RESOURCE_ID_LVS2_A", 		
+                                0x04, 		
+                                0x001B7740, 		
+                                0x000493E0, 		
+                                One, 		
+                                Zero		
+                            }		
+                        }, 		
+                        Package (0x02)		
+                        {		
+                            "PMICVREGVOTE", 		
+                            Package (0x0A)		
+                            {		
+                                "PPP_RESOURCE_ID_LDO18_A", 		
+                                One, 		
+                                0x002B7CD0, 		
+                                0x000927C0, 		
+                                One, 		
+                                Zero, 		
+                                One, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero		
+                            }		
+                        }, 		
+                        Package (0x02)		
+                        {		
+                            "TLMMGPIO", 		
+                            Package (0x06)		
+                            {		
+                                0x27, 		
+                                Zero, 		
+                                Zero, 		
+                                One, 		
+                                Zero, 		
+                                Zero		
+                            }		
+                        }		
+                    }		
+                }, 		
                 Package (0x06)
                 {
                     "DEVICE", 

--- a/AcpiTables/8992/src/SSDT.asl
+++ b/AcpiTables/8992/src/SSDT.asl
@@ -165,6 +165,81 @@ DefinitionBlock ("", "SSDT", 2, "MMO   ", "MSM8992 ", 0x00000012)
         {
             Name (_HID, "MSHW100D")  // _HID: Hardware ID
         }
+		
+        Device (SIAD)		
+        {		
+            Name (_HID, "MSHW100F")  // _HID: Hardware ID		
+            Name (_UID, One)  // _UID: Unique ID		
+            Name (_DEP, Package (0x03)  // _DEP: Dependencies		
+            {		
+                \_SB.PEP0, 		
+                \_SB.I2C7, 		
+                \_SB.GIO0		
+            })		
+            Method (_CRS, 0, NotSerialized)  // _CRS: Current Resource Settings		
+            {		
+                Name (RBUF, ResourceTemplate ()		
+                {		
+                    I2cSerialBusV2 (0x002C, ControllerInitiated, 0x00061A80,		
+                        AddressingMode7Bit, "\\_SB.I2C7",		
+                        0x00, ResourceConsumer, , Exclusive,		
+                        )		
+                    GpioIo (Exclusive, PullNone, 0x0000, 0x0000, IoRestrictionNone,		
+                        "\\_SB.GIO0", 0x00, ResourceConsumer, ,		
+                        )		
+                        {   // Pin list		
+                            0x0027		
+                        }		
+                    GpioInt (Edge, ActiveLow, Exclusive, PullUp, 0x0000,		
+                        "\\_SB.GIO0", 0x00, ResourceConsumer, ,		
+                        )		
+                        {   // Pin list		
+                            0x0060		
+                        }		
+                })		
+                Return (RBUF) /* \_SB_.SIAD._CRS.RBUF */		
+            }		
+            Name (PGID, Buffer (0x0A)		
+            {		
+                "\\_SB.SIAD"		
+            })		
+            Name (DBUF, Buffer (DBFL){})		
+            CreateByteField (DBUF, Zero, STAT)		
+            CreateByteField (DBUF, 0x02, DVAL)		
+            CreateField (DBUF, 0x18, 0xA0, DEID)		
+            Method (_S1D, 0, NotSerialized)  // _S1D: S1 Device State		
+            {		
+                Return (0x03)		
+            }		
+            Method (_S2D, 0, NotSerialized)  // _S2D: S2 Device State		
+            {		
+                Return (0x03)		
+            }		
+            Method (_S3D, 0, NotSerialized)  // _S3D: S3 Device State		
+            {		
+                Return (0x03)		
+            }		
+            Method (_PS0, 0, NotSerialized)  // _PS0: Power State 0		
+            {		
+                DEID = Buffer (ESNL){}		
+                DVAL = Zero		
+                DEID = PGID /* \_SB_.SIAD.PGID */		
+                If (\_SB.ABD.AVBL)		
+                {		
+                    \_SB.PEP0.FLD0 = DBUF /* \_SB_.SIAD.DBUF */		
+                }		
+            }		
+            Method (_PS3, 0, NotSerialized)  // _PS3: Power State 3		
+            {		
+                DEID = Buffer (ESNL){}		
+                DVAL = 0x03		
+                DEID = PGID /* \_SB_.SIAD.PGID */		
+                If (\_SB.ABD.AVBL)		
+                {		
+                    \_SB.PEP0.FLD0 = DBUF /* \_SB_.SIAD.DBUF */		
+                }		
+            }		
+        }
 
         Device (MCPU)
         {

--- a/AcpiTables/8994/src/DSDT.asl
+++ b/AcpiTables/8994/src/DSDT.asl
@@ -20701,8 +20701,161 @@ DefinitionBlock ("", "DSDT", 2, "QCOMM ", "MSM8994 ", 0x00000003)
                     }
                 }
             })
-            Name (CHXC, Package (0x04)
+            Name (CHXC, Package (0x05)
             {
+                Package (0x06)
+                {
+                    "DEVICE",
+                    "\\_SB.SIAD", 		
+                    Package (0x06)		
+                    {		
+                        "DSTATE", 		
+                        Zero, 		
+                        Package (0x02)		
+                        {		
+                            "PMICVREGVOTE", 		
+                            Package (0x0E)		
+                            {		
+                                "PPP_RESOURCE_ID_SMPS4_A", 		
+                                0x02, 		
+                                0x001B7740, 		
+                                0x000493E0, 		
+                                One, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero, 		
+                                0x05, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero		
+                            }		
+                        }, 		
+                        Package (0x02)		
+                        {		
+                            "PMICVREGVOTE", 		
+                            Package (0x06)		
+                            {		
+                                "PPP_RESOURCE_ID_LVS2_A", 		
+                                0x04, 		
+                                0x001B7740, 		
+                                0x000493E0, 		
+                                One, 		
+                                Zero		
+                            }		
+                        }, 		
+                        Package (0x02)		
+                        {		
+                            "PMICVREGVOTE", 		
+                            Package (0x0A)		
+                            {		
+                                "PPP_RESOURCE_ID_LDO18_A", 		
+                                One, 		
+                                0x002B7CD0, 		
+                                0x000927C0, 		
+                                One, 		
+                                Zero, 		
+                                One, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero		
+                            }		
+                        }, 		
+                        Package (0x02)		
+                        {		
+                            "TLMMGPIO", 		
+                            Package (0x06)		
+                            {		
+                                0x27, 		
+                                One, 		
+                                Zero, 		
+                                One, 		
+                                Zero, 		
+                                Zero		
+                            }		
+                        }		
+                    }, 		
+                    Package (0x02)		
+                    {		
+                        "DSTATE", 		
+                        One		
+                    }, 		
+                    Package (0x02)		
+                    {		
+                        "DSTATE", 		
+                        0x02		
+                    }, 		
+                    Package (0x06)		
+                    {		
+                        "DSTATE", 		
+                        0x03, 		
+                        Package (0x02)		
+                        {		
+                            "PMICVREGVOTE", 		
+                            Package (0x0E)		
+                            {		
+                                "PPP_RESOURCE_ID_SMPS4_A", 		
+                                0x02, 		
+                                0x001B7740, 		
+                                0x000493E0, 		
+                                One, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero, 		
+                                0x05, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero		
+                            }		
+                        }, 		
+                        Package (0x02)		
+                        {		
+                            "PMICVREGVOTE", 		
+                            Package (0x06)		
+                            {		
+                                "PPP_RESOURCE_ID_LVS2_A", 		
+                                0x04, 		
+                                0x001B7740, 		
+                                0x000493E0, 		
+                                One, 		
+                                Zero		
+                            }		
+                        }, 		
+                        Package (0x02)		
+                        {		
+                            "PMICVREGVOTE", 		
+                            Package (0x0A)		
+                            {		
+                                "PPP_RESOURCE_ID_LDO18_A", 		
+                                One, 		
+                                0x002B7CD0, 		
+                                0x000927C0, 		
+                                One, 		
+                                Zero, 		
+                                One, 		
+                                Zero, 		
+                                Zero, 		
+                                Zero		
+                            }		
+                        }, 		
+                        Package (0x02)		
+                        {		
+                            "TLMMGPIO", 		
+                            Package (0x06)		
+                            {		
+                                0x27, 		
+                                Zero, 		
+                                Zero, 		
+                                One, 		
+                                Zero, 		
+                                Zero		
+                            }		
+                        }		
+                    }		
+                },
                 Package (0x06)
                 {
                     "DEVICE", 

--- a/AcpiTables/8994/src/SSDT.asl
+++ b/AcpiTables/8994/src/SSDT.asl
@@ -165,6 +165,81 @@ DefinitionBlock ("", "SSDT", 2, "MMO   ", "MSM8994 ", 0x00000012)
         {
             Name (_HID, "MSHW100D")  // _HID: Hardware ID
         }
+		
+        Device (SIAD)		
+        {		
+            Name (_HID, "MSHW100F")  // _HID: Hardware ID		
+            Name (_UID, One)  // _UID: Unique ID		
+            Name (_DEP, Package (0x03)  // _DEP: Dependencies		
+            {		
+                \_SB.PEP0, 		
+                \_SB.I2C7, 		
+                \_SB.GIO0		
+            })		
+            Method (_CRS, 0, NotSerialized)  // _CRS: Current Resource Settings		
+            {		
+                Name (RBUF, ResourceTemplate ()		
+                {		
+                    I2cSerialBusV2 (0x002C, ControllerInitiated, 0x00061A80,		
+                        AddressingMode7Bit, "\\_SB.I2C7",		
+                        0x00, ResourceConsumer, , Exclusive,		
+                        )		
+                    GpioIo (Exclusive, PullNone, 0x0000, 0x0000, IoRestrictionNone,		
+                        "\\_SB.GIO0", 0x00, ResourceConsumer, ,		
+                        )		
+                        {   // Pin list		
+                            0x0027		
+                        }		
+                    GpioInt (Edge, ActiveLow, Exclusive, PullUp, 0x0000,		
+                        "\\_SB.GIO0", 0x00, ResourceConsumer, ,		
+                        )		
+                        {   // Pin list		
+                            0x0060		
+                        }		
+                })		
+                Return (RBUF) /* \_SB_.SIAD._CRS.RBUF */		
+            }		
+            Name (PGID, Buffer (0x0A)		
+            {		
+                "\\_SB.SIAD"		
+            })		
+            Name (DBUF, Buffer (DBFL){})		
+            CreateByteField (DBUF, Zero, STAT)		
+            CreateByteField (DBUF, 0x02, DVAL)		
+            CreateField (DBUF, 0x18, 0xA0, DEID)		
+            Method (_S1D, 0, NotSerialized)  // _S1D: S1 Device State		
+            {		
+                Return (0x03)		
+            }		
+            Method (_S2D, 0, NotSerialized)  // _S2D: S2 Device State		
+            {		
+                Return (0x03)		
+            }		
+            Method (_S3D, 0, NotSerialized)  // _S3D: S3 Device State		
+            {		
+                Return (0x03)		
+            }		
+            Method (_PS0, 0, NotSerialized)  // _PS0: Power State 0		
+            {		
+                DEID = Buffer (ESNL){}		
+                DVAL = Zero		
+                DEID = PGID /* \_SB_.SIAD.PGID */		
+                If (\_SB.ABD.AVBL)		
+                {		
+                    \_SB.PEP0.FLD0 = DBUF /* \_SB_.SIAD.DBUF */		
+                }		
+            }		
+            Method (_PS3, 0, NotSerialized)  // _PS3: Power State 3		
+            {		
+                DEID = Buffer (ESNL){}		
+                DVAL = 0x03		
+                DEID = PGID /* \_SB_.SIAD.PGID */		
+                If (\_SB.ABD.AVBL)		
+                {		
+                    \_SB.PEP0.FLD0 = DBUF /* \_SB_.SIAD.DBUF */		
+                }		
+            }		
+        }
 
         Device (MCPU)
         {


### PR DESCRIPTION
- Based on FW1072

Requires rebuilding the built in acpi tables or #77 
Version of SSDT should be bumped but due to simultaneous ACPI PRs this hasn't been done