### PR TITLE
ACPI: Add TPM2 ACPI tables from FW1078 for reference [skip ci]

### DIFF
--- a/AcpiTables/8992/src/TPM2.asl
+++ b/AcpiTables/8992/src/TPM2.asl
@@ -1,0 +1,13 @@
+[000h 0000   4]                    Signature : "TPM2"    [Trusted Platform Module hardware interface table]
+[004h 0004   4]                 Table Length : 00000054
+[008h 0008   1]                     Revision : 03
+[009h 0009   1]                     Checksum : 00     /* Incorrect checksum, should be 89 */
+[00Ah 0010   6]                       Oem ID : "QCOM  "
+[010h 0016   8]                 Oem Table ID : "QCOMEDK2"
+[018h 0024   4]                 Oem Revision : 00008994
+[01Ch 0028   4]              Asl Compiler ID : "QCOM"
+[020h 0032   4]        Asl Compiler Revision : 00000001
+
+[024h 0036   4]                     Reserved : 00000000
+[028h 0040   8]              Control Address : 0000000000000000
+[030h 0048   4]                 Start Method : 00000009

--- a/AcpiTables/8994/src/TPM2.asl
+++ b/AcpiTables/8994/src/TPM2.asl
@@ -1,0 +1,13 @@
+[000h 0000   4]                    Signature : "TPM2"    [Trusted Platform Module hardware interface table]
+[004h 0004   4]                 Table Length : 00000054
+[008h 0008   1]                     Revision : 03
+[009h 0009   1]                     Checksum : 00     /* Incorrect checksum, should be 89 */
+[00Ah 0010   6]                       Oem ID : "QCOM  "
+[010h 0016   8]                 Oem Table ID : "QCOMEDK2"
+[018h 0024   4]                 Oem Revision : 00008994
+[01Ch 0028   4]              Asl Compiler ID : "QCOM"
+[020h 0032   4]        Asl Compiler Revision : 00000001
+
+[024h 0036   4]                     Reserved : 00000000
+[028h 0040   8]              Control Address : 0000000000000000
+[030h 0048   4]                 Start Method : 00000009

--- a/AcpiTables/Hapanero/src/TPM2.asl
+++ b/AcpiTables/Hapanero/src/TPM2.asl
@@ -1,0 +1,13 @@
+[000h 0000   4]                    Signature : "TPM2"    [Trusted Platform Module hardware interface table]
+[004h 0004   4]                 Table Length : 00000054
+[008h 0008   1]                     Revision : 03
+[009h 0009   1]                     Checksum : 00     /* Incorrect checksum, should be 89 */
+[00Ah 0010   6]                       Oem ID : "QCOM  "
+[010h 0016   8]                 Oem Table ID : "QCOMEDK2"
+[018h 0024   4]                 Oem Revision : 00008994
+[01Ch 0028   4]              Asl Compiler ID : "QCOM"
+[020h 0032   4]        Asl Compiler Revision : 00000001
+
+[024h 0036   4]                     Reserved : 00000000
+[028h 0040   8]              Control Address : 0000000000000000
+[030h 0048   4]                 Start Method : 00000009


### PR DESCRIPTION
These tables are not referenced as part of the build process and are only for reference purposes