### PR TITLE
CI: Update to latest vmImage ahead of current image deprecation

### DIFF
--- a/Tools/CI/Bootstrapper/Stage0.sh
+++ b/Tools/CI/Bootstrapper/Stage0.sh
@@ -17,13 +17,14 @@ echo "Installing build components..."
 # Host utilities
 apt-get install git-core git
 apt-get install build-essential
+apt-get install python
 
 # PowerShell
 # Import the public repository GPG keys
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 
 # Register the Microsoft Ubuntu repository
-curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list
+curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list
 
 # Update the list of products
 apt-get update

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ trigger:
     - LICENSE
 
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: 'Ubuntu-latest'
 
 steps:
 - script: sudo apt update 


### PR DESCRIPTION
Currently Azure Pipelines is warning that the currently used vmImage is going to be deprecated very soon, this PR updates CI files to support latest vmImage versions.

```
##[warning]Ubuntu 16.04 LTS environment is deprecated and will be removed on September 20, 2021. Migrate to ubuntu-latest instead. For more details, see https://github.com/actions/virtual-environments/issues/3287.
```